### PR TITLE
1/write image file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "3.1.1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,22 @@
 use std::path::PathBuf;
+use std::fs::File;
+use std::io::prelude::*;
 
 #[derive(Debug)]
 pub struct Disk {
     path: PathBuf,
+    size: u64,
 }
 
 impl Disk {
     pub fn new(path: &str, size: u64) -> Disk {
         Disk {
             path: PathBuf::from(path),
+            size: size,
         }
+    }
+    pub fn write(&self) {
+        let mut f = File::create(self.path.as_path()).expect("Failed to create file.");
+        f.set_len(self.size).expect("Failed to grow file to requested size.");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct Disk {
+    path: PathBuf,
+}
+
+impl Disk {
+    pub fn new(path: &str, size: u64) -> Disk {
+        Disk {
+            path: PathBuf::from(path),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the disk image to create
+    #[clap(short, long)]
+    path: String,
+}
 fn main() {
-    println!("Hello, world!");
+    let args = Args::parse();
+    println!("Create file at: {}", args.path);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,20 @@
+use doscontainer::Disk;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(version, about = "DOS Container generates MS-DOS compatible disk images.", long_about = None)]
 struct Args {
     /// Path to the disk image to create
     #[clap(short, long)]
     path: String,
+
+    /// Disk size in bytes
+    #[clap(short, long)]
+    size: u64,
 }
 fn main() {
     let args = Args::parse();
+    let mut my_disk = Disk::new(args.path.as_str(), args.size);
     println!("Create file at: {}", args.path);
+    println!("Disk size will be: {} byes.", args.size);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let mut my_disk = Disk::new(args.path.as_str(), args.size);
+    my_disk.write();
     println!("Create file at: {}", args.path);
     println!("Disk size will be: {} byes.", args.size);
 }


### PR DESCRIPTION
The doscontainer program now takes two parameters:
  -- path: location of the file to be written
  --size: size of the file in bytes.
It proceeds to clobber whatever is in its way and writes a file there with the requested size. It'll fail catastrophically if it can't do its thing, but for now the mission of this issue is accomplished. Proper error handling is a bigger, cross-cutting task that deserves its own issue.