### PR TITLE
9/chs calculation algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitvec = "1"
 clap = { version = "3.1.1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,11 @@ impl Disk {
         let sector_size = 512;
         let bootcode = include_bytes!("msdos622-bootcode.bin");
         Disk {
-            path: PathBuf::from(path),
-            geometry: CHS::empty(),
-            size: size,
-            sector_count: size / sector_size,
             bootcode: *bootcode,
+            geometry: CHS::empty(),
+            path: PathBuf::from(path),
+            sector_count: size / sector_size,
+            size: size,
         }
     }
     // Bochs geomtry algorithm for the 'no translation' case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,29 +2,36 @@ use std::path::PathBuf;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Write;
+use bitvec::prelude::*;
 
 #[derive(Debug)]
 pub struct Disk {
     bootcode: [u8; 446],
     geometry: CHS,
     path: PathBuf,
-    sector_count: u64,
-    sector_size: u64,
     size: u64,
 }
 
 impl Disk {
     pub fn new(path: &str, size: u64) -> Disk {
-        if size > 528482304 { panic!("Disk too big!"); }
-        let sector_size = 512;
         let bootcode = include_bytes!("msdos622-bootcode.bin");
         Disk {
             bootcode: *bootcode,
-            geometry: Disk::geometry_none(size),
+            geometry: Disk::calculate_geometry(size),
             path: PathBuf::from(path),
-            sector_count: size / sector_size,
-            sector_size: 512,
             size: size,
+        }
+    }
+    pub fn calculate_geometry(size: u64) -> CHS {
+        // Small disks use the 'none' algorithm
+        if size < 528482304 {
+            return Disk::geometry_none(size);
+        }
+        if size < 4227858432 {
+            return Disk::geometry_large(size);
+        }
+        else {
+            panic!("No suitable geometry algorithm available. Disk is probably too big.");
         }
     }
     // Bochs geomtry algorithm for the 'no translation' case.
@@ -40,12 +47,16 @@ impl Disk {
             geom.sector = 63;
             if cylinders < 1023 { break; }
         }
-        println!("{:?}", geom);
         return geom;
+    }
+    fn geometry_large(size: u64) -> CHS {
+        // Empty placeholder for now so this compiles.
+        return CHS::empty();
     }
     pub fn write(&self) {
         let f = File::create(self.path.as_path()).expect("Failed to create file.");
         f.set_len(self.size).expect("Failed to grow file to requested size.");
+        self.geometry.as_bytes();
     }
     pub fn write_bootcode(&self) {
         let mut file = OpenOptions::new().write(true).open(&self.path).expect("Failed to open file.");
@@ -67,6 +78,29 @@ impl CHS {
             cylinder: 0,
             head: 0,
             sector: 0
+        }
+    }
+    // Calculate triplet of CHS bytes for use in partition tables
+    // https://thestarman.pcministry.com/asm/mbr/PartTables.htm#mbr
+    pub fn as_bytes(&self) -> [u8; 3] {
+        // Handle the simple case: values all fit in their own bytes.
+        if self.cylinder <= 255 {
+            return [
+                u8::try_from(self.cylinder).unwrap(),
+                u8::try_from(self.head).unwrap(),
+                u8::try_from(self.sector).unwrap(), ]
+        }
+        // The cylinders value can go to 1024, which needs 10 bits.
+        // I don't know how to do the bit-twiddling yet to make this
+        // fit across the 3 bytes that the MBR permits for this.
+        else {
+             // Turn the cylinders u16 into a BitVec so we can twiddle bits
+             let mut cylinders_as_bits = BitVec::<_, Msb0>::from_element(self.cylinder);
+             cylinders_as_bits.drain(0..=5); // Clip off the first 6 unwanted bits
+             let sectors_as_bits = BitVec::<_, Msb0>::from_element(self.sector);
+             println!("Cylinders as bits {:?}", cylinders_as_bits);
+             println!("Sectors as bits {:?}", sectors_as_bits);
+             [0, 0, 0]
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,11 @@ use std::io::Write;
 
 #[derive(Debug)]
 pub struct Disk {
-    path: PathBuf,
-    size: u64,
-    sector_count: u64,
     bootcode: [u8; 446],
+    geometry: CHS,
+    path: PathBuf,
+    sector_count: u64,
+    size: u64,
 }
 
 impl Disk {
@@ -17,10 +18,16 @@ impl Disk {
         let bootcode = include_bytes!("msdos622-bootcode.bin");
         Disk {
             path: PathBuf::from(path),
+            geometry: CHS::empty(),
             size: size,
             sector_count: size / sector_size,
             bootcode: *bootcode,
         }
+    }
+    // Bochs geomtry algorithm for the 'no translation' case.
+    // Disks that remain within the original int13h limit of 528MB.
+    fn geometry_none(&self) -> CHS {
+        return CHS::empty();
     }
     pub fn write(&self) {
         let mut f = File::create(self.path.as_path()).expect("Failed to create file.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
 }
 fn main() {
     let args = Args::parse();
-    let mut my_disk = Disk::new(args.path.as_str(), args.size);
+    let my_disk = Disk::new(args.path.as_str(), args.size);
     my_disk.write();
     my_disk.write_bootcode();
     println!("Create file at: {}", args.path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,4 +19,5 @@ fn main() {
     my_disk.write_bootcode();
     println!("Create file at: {}", args.path);
     println!("Disk size will be: {} byes.", args.size);
+    println!("{:?}", my_disk);
 }


### PR DESCRIPTION
The CHS type works for geometry_none now, and it contains a function to generate CHS bytes to be used in a partition. Merge this PR so we can start work on partitioning. Once a partition can be written, we can properly validate that this work is entirely correct and flesh out the other algorithms. Don't close the issue just yet.